### PR TITLE
Decrease chart element initialization time.

### DIFF
--- a/projects/ng-apexcharts/package.json
+++ b/projects/ng-apexcharts/package.json
@@ -5,6 +5,7 @@
   "peerDependencies": {
     "@angular/common": "^7.1.0",
     "@angular/core": "^7.1.0",
+    "rxjs": "^6.3.0",
     "apexcharts": "^3.3.1"
   },
   "keywords": [

--- a/projects/ng-apexcharts/src/lib/chart/chart.component.ts
+++ b/projects/ng-apexcharts/src/lib/chart/chart.component.ts
@@ -16,6 +16,7 @@ import {
   ApexXAxis,
   ApexYAxis
 } from '../model/apex-types';
+import { asapScheduler } from 'rxjs';
 
 declare var ApexCharts: any;
 
@@ -58,9 +59,9 @@ export class ChartComponent implements OnInit, OnChanges {
   private chartObj: any;
 
   ngOnInit() {
-    setTimeout(() => {
+    asapScheduler.schedule(() => {
       this.createElement();
-    }, 0);
+    });
   }
 
   ngOnChanges(changes: SimpleChanges): void {


### PR DESCRIPTION
In some particular cases, when the root element property set on creation and I try to update chart options (in my case trying to set height), I got this:
```
ERROR TypeError: Cannot read property 'updateOptions' of undefined
    at ChartComponent.push../node_modules/ng-apexcharts/fesm5/ng-apexcharts.js.ChartComponent.updateOptions (ng-apexcharts.js:156). 
```
The chart object inside _ng-apexcharts_ created using `setTimeout`  and because `setTimeout` has a delay, minimum **4ms** as described in specs, I should use something like this `setTimeout(callbackFn, 5)`. In here `asapScheduler`, `Promise.resolve().then()` or `window.postMessage` can be used for decrease delay.